### PR TITLE
Do not consider group sizes to be even with the wavesize if WAVESIZE is 1 for the Agent

### DIFF
--- a/src/hexl/hexl_emitter/CoreConfig.cpp
+++ b/src/hexl/hexl_emitter/CoreConfig.cpp
@@ -178,7 +178,7 @@ CoreConfig::GridsConfig::GridsConfig(CoreConfig* cc)
   fbarrier->Add(NEWA GridGeometry(3, 2, 32, 4, 2, 32, 4));
   fbarrier->Add(NEWA GridGeometry(3, 5, 7, 12, 3, 5, 7));
   fbarrier->Add(NEWA GridGeometry(3, 3, 9, 13, 2, 7, 11));
-  if (cc->WavesPerGroup() > 1) {
+  if (cc->Wavesize() > 1 && cc->WavesPerGroup() > 1) {
     fbarrierEven->Add(NEWA GridGeometry(1, cc->Wavesize()*4, 1, 1, cc->Wavesize()*2, 1, 1));
     fbarrierEven->Add(NEWA GridGeometry(2, 4, cc->Wavesize(), 1, 2, cc->Wavesize(), 1));
     if (cc->WavesPerGroup() >= 4) {


### PR DESCRIPTION
Some of the fbarrier tests seem to assume that when the group is even with wavesize there are more than one WIs per wave and run into a deadlock.

At least **prm/core/parallel/fbarrier/example3/1_8x1x1_4x1x1** hangs with a PHSA CPU agent which has WAVESIZE = 1 and an unfortunate max group size (with non-zero lowest 8 bits?).